### PR TITLE
Fixes alignment within the realm selector dropdown

### DIFF
--- a/src/components/realm-selector/RealmSelector.tsx
+++ b/src/components/realm-selector/RealmSelector.tsx
@@ -34,7 +34,7 @@ export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
     realmName.charAt(0).toUpperCase() + realmName.slice(1);
 
   const RealmText = ({ value }: { value: string }) => (
-    <Split>
+    <Split className="keycloak__realm_selector__list-item-split">
       <SplitItem isFilled>{toUpperCase(value)}</SplitItem>
       <SplitItem>{value === realm && <CheckIcon />}</SplitItem>
     </Split>
@@ -101,7 +101,7 @@ export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
             </ContextSelectorItem>
           ))}
           <ContextSelectorItem key="add">
-            <AddRealm className="keycloak__realm_selector__create_realm_button" />
+            <AddRealm  />
           </ContextSelectorItem>
         </ContextSelector>
       )}

--- a/src/components/realm-selector/realm-selector.css
+++ b/src/components/realm-selector/realm-selector.css
@@ -22,14 +22,20 @@
   --pf-c-context-selector__toggle--Color: var(--pf-c-nav__link--m-current--Color);
 }
 
-.keycloak__realm_selector__create_realm_button {
-  position: absolute;
-  left: 0;
-  bottom: -36px;
-}
-
 .keycloak__realm_selector__dropdown {
   width: 100%;
+}
+
+.keycloak__realm_selector__list-item-split {
+  width: 100%;
+  text-align: left;
+}
+
+/* the last child is the realm selector button, and this is the only way to style the li around it */
+.keycloak__realm_selector__context_selector li:last-child {
+  position: sticky;
+  bottom: 0;
+  background-color: var(--pf-c-context-selector__menu--BackgroundColor);
 }
 
 .keycloak__page_nav__nav_item__realm-selector {


### PR DESCRIPTION
This should fix up the space around the button, allow it to stick even if there are more realms listed than can fit, and moves the checkmark over to the right of the individual selected realm.